### PR TITLE
yarn dev script update for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
   "scripts": {
-    "dev": "NODE_OPTIONS='--inspect' next dev",
+    "dev": "SET NODE_OPTIONS=--inspect && next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION
'NODE_OPTIONS' is not recognized in windows CLI when running 'yarn dev'. The changes in my PR should fix that and make it work on all devices.